### PR TITLE
Update examples and fix broken queries

### DIFF
--- a/examples/variant_analysis.ipynb
+++ b/examples/variant_analysis.ipynb
@@ -5,21 +5,23 @@
    "id": "initial_id",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T20:35:12.308799Z",
-     "start_time": "2025-06-18T20:35:12.079276Z"
+     "end_time": "2025-07-16T18:32:16.803736Z",
+     "start_time": "2025-07-16T18:32:16.779567Z"
     }
    },
    "source": [
+    "from patternq.dataset import sample_measurements\n",
     "%%capture\n",
     "%load_ext autoreload\n",
     "%autoreload 2\n",
     "import pandas as pd\n",
     "import patternq.query as pqq\n",
     "import patternq.dataset as pqd\n",
-    "import patternq.reference as pqr"
+    "import patternq.reference as pqr\n",
+    "import patternq.schema as pqs"
    ],
    "outputs": [],
-   "execution_count": 1
+   "execution_count": 5
   },
   {
    "metadata": {},
@@ -35,8 +37,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T20:35:12.326027Z",
-     "start_time": "2025-06-18T20:35:12.312446Z"
+     "end_time": "2025-07-16T18:32:21.137347Z",
+     "start_time": "2025-07-16T18:32:21.112081Z"
     }
    },
    "cell_type": "code",
@@ -48,19 +50,63 @@
    ],
    "id": "3e9e5957368f074e",
    "outputs": [],
-   "execution_count": 2
+   "execution_count": 6
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-07-16T18:33:25.670970Z",
+     "start_time": "2025-07-16T18:33:25.657410Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "# using tcga data\n",
+    "dataset = 'tcga-brca'\n",
+    "database = 'tcga-brca'"
+   ],
+   "id": "b9fd56208d227656",
+   "outputs": [],
+   "execution_count": 13
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-07-16T18:33:34.379362Z",
+     "start_time": "2025-07-16T18:33:33.801972Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "# verify schema version\n",
+    "pqs.schema_info(db_name=database)"
+   ],
+   "id": "83ac1db50cf9b62e",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "SchemaInfo(name=':org.rcrf/candel', version='1.3.1')"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 15
   },
   {
    "cell_type": "code",
    "id": "79f2439641b3d0d6",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T20:35:13.140010Z",
-     "start_time": "2025-06-18T20:35:12.399750Z"
+     "end_time": "2025-07-16T18:33:37.302074Z",
+     "start_time": "2025-07-16T18:33:36.586320Z"
     }
    },
    "source": [
-    "subjects = pqd.all_subjects('tcga-brca', db_name='tcga-brca')\n",
+    "subjects = pqd.subjects('tcga-brca', db_name='tcga-brca')\n",
     "subjects"
    ],
    "outputs": [
@@ -352,12 +398,12 @@
        "</div>"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 3
+   "execution_count": 16
   },
   {
    "metadata": {},
@@ -373,8 +419,8 @@
    "id": "eefb2df20c58950c",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T20:35:13.188697Z",
-     "start_time": "2025-06-18T20:35:13.172139Z"
+     "end_time": "2025-07-16T18:33:41.488586Z",
+     "start_time": "2025-07-16T18:33:41.464999Z"
     }
    },
    "source": [
@@ -511,12 +557,12 @@
        "</div>"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 4
+   "execution_count": 17
   },
   {
    "metadata": {},
@@ -529,8 +575,8 @@
    "id": "6c6ffaa2d8cc0d78",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T20:35:13.254048Z",
-     "start_time": "2025-06-18T20:35:13.244391Z"
+     "end_time": "2025-07-16T18:33:45.774882Z",
+     "start_time": "2025-07-16T18:33:45.756032Z"
     }
    },
    "source": [
@@ -555,20 +601,20 @@
        "Name: count, Length: 102, dtype: int64"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 5
+   "execution_count": 18
   },
   {
    "cell_type": "code",
    "id": "f8982b790a03f6ed",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T20:35:13.348395Z",
-     "start_time": "2025-06-18T20:35:13.335850Z"
+     "end_time": "2025-07-16T18:33:48.742225Z",
+     "start_time": "2025-07-16T18:33:48.721298Z"
     }
    },
    "source": [
@@ -705,12 +751,12 @@
        "</div>"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 6
+   "execution_count": 19
   },
   {
    "metadata": {},
@@ -723,13 +769,13 @@
    "id": "bb87ca446c002c8a",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T20:35:13.904814Z",
-     "start_time": "2025-06-18T20:35:13.403754Z"
+     "end_time": "2025-07-16T18:34:26.070469Z",
+     "start_time": "2025-07-16T18:34:10.405482Z"
     }
    },
    "source": [
     "sub_ids = b27_sub['subject-id'].unique().tolist()\n",
-    "assays_for_sub = pqd.assays_for_patients(sub_ids, db_name='tcga-brca')\n",
+    "assays_for_sub = pqd.patient_assays(dataset, sub_ids, db_name='tcga-brca')\n",
     "assays_for_sub"
    ],
    "outputs": [
@@ -885,20 +931,20 @@
        "</div>"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 7
+   "execution_count": 22
   },
   {
    "cell_type": "code",
    "id": "f229b14d787db808",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T20:35:14.760458Z",
-     "start_time": "2025-06-18T20:35:13.953735Z"
+     "end_time": "2025-07-16T18:34:28.856633Z",
+     "start_time": "2025-07-16T18:34:27.983642Z"
     }
    },
    "source": [
@@ -1169,20 +1215,20 @@
        "</div>"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 8
+   "execution_count": 23
   },
   {
    "cell_type": "code",
    "id": "3d4c35905609659e",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T20:35:14.813688Z",
-     "start_time": "2025-06-18T20:35:14.797189Z"
+     "end_time": "2025-07-16T18:34:31.397208Z",
+     "start_time": "2025-07-16T18:34:31.373377Z"
     }
    },
    "source": [
@@ -1453,12 +1499,12 @@
        "</div>"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 9
+   "execution_count": 24
   },
   {
    "metadata": {},
@@ -1475,8 +1521,8 @@
    "id": "a2653774454e7b68",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T20:35:15.357250Z",
-     "start_time": "2025-06-18T20:35:14.890879Z"
+     "end_time": "2025-07-16T18:34:35.095273Z",
+     "start_time": "2025-07-16T18:34:34.512081Z"
     }
    },
    "source": [
@@ -1522,20 +1568,20 @@
        "</div>"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 10
+   "execution_count": 25
   },
   {
    "cell_type": "code",
    "id": "44f9e8e55a7f7e88",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T20:35:15.414836Z",
-     "start_time": "2025-06-18T20:35:15.402078Z"
+     "end_time": "2025-07-16T18:34:37.570784Z",
+     "start_time": "2025-07-16T18:34:37.552736Z"
     }
    },
    "source": [
@@ -1695,12 +1741,42 @@
        "</div>"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 11
+   "execution_count": 26
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-07-16T18:48:17.201130Z",
+     "start_time": "2025-07-16T18:48:17.190654Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "assays_for_sub['measurement-set-name'].value_counts()",
+   "id": "7bba60b31b00bf0d",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "measurement-set-name\n",
+       "immune-cell-deconvolution    173\n",
+       "snp CNV data                 170\n",
+       "gx                            91\n",
+       "tumor purity                  85\n",
+       "baseline mutations            82\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 54,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 54
   },
   {
    "metadata": {},
@@ -1716,8 +1792,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T20:35:16.403708Z",
-     "start_time": "2025-06-18T20:35:15.507751Z"
+     "end_time": "2025-07-16T18:34:41.863961Z",
+     "start_time": "2025-07-16T18:34:40.450227Z"
     }
    },
    "cell_type": "code",
@@ -1894,12 +1970,12 @@
        "</div>"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 12
+   "execution_count": 27
   },
   {
    "metadata": {},
@@ -1916,8 +1992,8 @@
    "id": "3013e87d1d690659",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T20:35:17.860510Z",
-     "start_time": "2025-06-18T20:35:16.441488Z"
+     "end_time": "2025-07-16T18:34:46.624643Z",
+     "start_time": "2025-07-16T18:34:44.829454Z"
     }
    },
    "source": [
@@ -2177,12 +2253,12 @@
        "</div>"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 13
+   "execution_count": 28
   },
   {
    "metadata": {},
@@ -2199,8 +2275,8 @@
    "id": "9c34888ffd0dd9ca",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T20:35:17.916425Z",
-     "start_time": "2025-06-18T20:35:17.900074Z"
+     "end_time": "2025-07-16T18:34:49.855870Z",
+     "start_time": "2025-07-16T18:34:49.829977Z"
     }
    },
    "source": [
@@ -2520,12 +2596,12 @@
        "</div>"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 14
+   "execution_count": 29
   },
   {
    "metadata": {},
@@ -2538,13 +2614,11 @@
    "id": "8f53087db8f6e263",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T20:35:17.972883Z",
-     "start_time": "2025-06-18T20:35:17.958269Z"
+     "end_time": "2025-07-16T18:34:54.825153Z",
+     "start_time": "2025-07-16T18:34:54.801610Z"
     }
    },
-   "source": [
-    "w_var[w_var['variant-classification'] == ':variant.classification/missense']"
-   ],
+   "source": "w_var[w_var['variant-classification'] == ':variant.classification/missense']",
    "outputs": [
     {
      "data": {
@@ -2847,12 +2921,596 @@
        "</div>"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 15
+   "execution_count": 30
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-07-16T18:42:14.036345Z",
+     "start_time": "2025-07-16T18:42:14.018915Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "assays_for_sub[['sample-id', 'measurement-set-name']]",
+   "id": "e78b120c4b3d7259",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "            sample-id       measurement-set-name\n",
+       "0    tcga-a2-a0er-10a  immune-cell-deconvolution\n",
+       "1    tcga-a2-a0st-10a  immune-cell-deconvolution\n",
+       "2    tcga-a7-a13h-01a               snp CNV data\n",
+       "3    tcga-an-a0al-01a               snp CNV data\n",
+       "4    tcga-a8-a099-01a         baseline mutations\n",
+       "..                ...                        ...\n",
+       "596  tcga-a2-a04v-01a                         gx\n",
+       "597  tcga-ac-a3w6-01a         baseline mutations\n",
+       "598  tcga-ol-a66h-01a               tumor purity\n",
+       "599  tcga-e9-a1r6-01a  immune-cell-deconvolution\n",
+       "600  tcga-ao-a0jd-01a         baseline mutations\n",
+       "\n",
+       "[601 rows x 2 columns]"
+      ],
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>sample-id</th>\n",
+       "      <th>measurement-set-name</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>tcga-a2-a0er-10a</td>\n",
+       "      <td>immune-cell-deconvolution</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>tcga-a2-a0st-10a</td>\n",
+       "      <td>immune-cell-deconvolution</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>tcga-a7-a13h-01a</td>\n",
+       "      <td>snp CNV data</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>tcga-an-a0al-01a</td>\n",
+       "      <td>snp CNV data</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>tcga-a8-a099-01a</td>\n",
+       "      <td>baseline mutations</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>596</th>\n",
+       "      <td>tcga-a2-a04v-01a</td>\n",
+       "      <td>gx</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>597</th>\n",
+       "      <td>tcga-ac-a3w6-01a</td>\n",
+       "      <td>baseline mutations</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>598</th>\n",
+       "      <td>tcga-ol-a66h-01a</td>\n",
+       "      <td>tumor purity</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>599</th>\n",
+       "      <td>tcga-e9-a1r6-01a</td>\n",
+       "      <td>immune-cell-deconvolution</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>600</th>\n",
+       "      <td>tcga-ao-a0jd-01a</td>\n",
+       "      <td>baseline mutations</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>601 rows × 2 columns</p>\n",
+       "</div>"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 41
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-07-16T18:43:23.871438Z",
+     "start_time": "2025-07-16T18:43:23.351021Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "purity_df = pqd.sample_measurements(dataset, 'tumor purity', assays_for_sub['sample-id'].unique().tolist(), db_name=database, timeout=120)\n",
+    "purity_df"
+   ],
+   "id": "6072d7b6eea6cacc",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "             db-id    measurement-id  \\\n",
+       "0   17592188233843  tcga-a1-a0sh-01a   \n",
+       "1   17592188233873  tcga-a2-a04v-01a   \n",
+       "2   17592188233877  tcga-a2-a04x-01a   \n",
+       "3   17592188233913  tcga-a2-a0d1-01a   \n",
+       "4   17592188233926  tcga-a2-a0eo-01a   \n",
+       "..             ...               ...   \n",
+       "80  17592188235806  tcga-ew-a3u0-01a   \n",
+       "81  17592188235923  tcga-ll-a9q3-01a   \n",
+       "82  17592188235938  tcga-ol-a5da-01a   \n",
+       "83  17592188235954  tcga-ol-a66h-01a   \n",
+       "84  17592188236026  tcga-z7-a8r5-01a   \n",
+       "\n",
+       "                                  measurement-uid  measurement-tumor-purity  \\\n",
+       "0   [tcga-brca, fafc777825d48b83c123f20c2ae222e4]                    0.6574   \n",
+       "1   [tcga-brca, 526790b7270e3350267f925389583cf1]                    0.8341   \n",
+       "2   [tcga-brca, 24013d8c7199288318687bdecf318186]                    0.7223   \n",
+       "3   [tcga-brca, 778a6e9db87be8c19f5883381102c1bc]                    0.8980   \n",
+       "4   [tcga-brca, 11e54d89b3f3f9a87cda81ce059aa0e6]                    0.6086   \n",
+       "..                                            ...                       ...   \n",
+       "80  [tcga-brca, 0d92a32853dade598a90bd563ef3c903]                    0.4688   \n",
+       "81  [tcga-brca, 4ddfd382a8225ddfe0abf2c535d152a3]                    0.7531   \n",
+       "82  [tcga-brca, e4e430917944ef4c38f4f8012b6622f2]                    0.8184   \n",
+       "83  [tcga-brca, 4c586df7b791fa2a0f97977e43725789]                    0.7466   \n",
+       "84  [tcga-brca, b058e4291d10988c8608eb7cc44ef5c8]                    0.6919   \n",
+       "\n",
+       "   measurement-sample-sample-id  \n",
+       "0              tcga-a1-a0sh-01a  \n",
+       "1              tcga-a2-a04v-01a  \n",
+       "2              tcga-a2-a04x-01a  \n",
+       "3              tcga-a2-a0d1-01a  \n",
+       "4              tcga-a2-a0eo-01a  \n",
+       "..                          ...  \n",
+       "80             tcga-ew-a3u0-01a  \n",
+       "81             tcga-ll-a9q3-01a  \n",
+       "82             tcga-ol-a5da-01a  \n",
+       "83             tcga-ol-a66h-01a  \n",
+       "84             tcga-z7-a8r5-01a  \n",
+       "\n",
+       "[85 rows x 5 columns]"
+      ],
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>db-id</th>\n",
+       "      <th>measurement-id</th>\n",
+       "      <th>measurement-uid</th>\n",
+       "      <th>measurement-tumor-purity</th>\n",
+       "      <th>measurement-sample-sample-id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>17592188233843</td>\n",
+       "      <td>tcga-a1-a0sh-01a</td>\n",
+       "      <td>[tcga-brca, fafc777825d48b83c123f20c2ae222e4]</td>\n",
+       "      <td>0.6574</td>\n",
+       "      <td>tcga-a1-a0sh-01a</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>17592188233873</td>\n",
+       "      <td>tcga-a2-a04v-01a</td>\n",
+       "      <td>[tcga-brca, 526790b7270e3350267f925389583cf1]</td>\n",
+       "      <td>0.8341</td>\n",
+       "      <td>tcga-a2-a04v-01a</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>17592188233877</td>\n",
+       "      <td>tcga-a2-a04x-01a</td>\n",
+       "      <td>[tcga-brca, 24013d8c7199288318687bdecf318186]</td>\n",
+       "      <td>0.7223</td>\n",
+       "      <td>tcga-a2-a04x-01a</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>17592188233913</td>\n",
+       "      <td>tcga-a2-a0d1-01a</td>\n",
+       "      <td>[tcga-brca, 778a6e9db87be8c19f5883381102c1bc]</td>\n",
+       "      <td>0.8980</td>\n",
+       "      <td>tcga-a2-a0d1-01a</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>17592188233926</td>\n",
+       "      <td>tcga-a2-a0eo-01a</td>\n",
+       "      <td>[tcga-brca, 11e54d89b3f3f9a87cda81ce059aa0e6]</td>\n",
+       "      <td>0.6086</td>\n",
+       "      <td>tcga-a2-a0eo-01a</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>80</th>\n",
+       "      <td>17592188235806</td>\n",
+       "      <td>tcga-ew-a3u0-01a</td>\n",
+       "      <td>[tcga-brca, 0d92a32853dade598a90bd563ef3c903]</td>\n",
+       "      <td>0.4688</td>\n",
+       "      <td>tcga-ew-a3u0-01a</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>81</th>\n",
+       "      <td>17592188235923</td>\n",
+       "      <td>tcga-ll-a9q3-01a</td>\n",
+       "      <td>[tcga-brca, 4ddfd382a8225ddfe0abf2c535d152a3]</td>\n",
+       "      <td>0.7531</td>\n",
+       "      <td>tcga-ll-a9q3-01a</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>82</th>\n",
+       "      <td>17592188235938</td>\n",
+       "      <td>tcga-ol-a5da-01a</td>\n",
+       "      <td>[tcga-brca, e4e430917944ef4c38f4f8012b6622f2]</td>\n",
+       "      <td>0.8184</td>\n",
+       "      <td>tcga-ol-a5da-01a</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>83</th>\n",
+       "      <td>17592188235954</td>\n",
+       "      <td>tcga-ol-a66h-01a</td>\n",
+       "      <td>[tcga-brca, 4c586df7b791fa2a0f97977e43725789]</td>\n",
+       "      <td>0.7466</td>\n",
+       "      <td>tcga-ol-a66h-01a</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>84</th>\n",
+       "      <td>17592188236026</td>\n",
+       "      <td>tcga-z7-a8r5-01a</td>\n",
+       "      <td>[tcga-brca, b058e4291d10988c8608eb7cc44ef5c8]</td>\n",
+       "      <td>0.6919</td>\n",
+       "      <td>tcga-z7-a8r5-01a</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>85 rows × 5 columns</p>\n",
+       "</div>"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 44
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-07-16T18:45:53.477933Z",
+     "start_time": "2025-07-16T18:45:53.458247Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "cnv_samples = assays_for_sub[assays_for_sub['measurement-set-name'] == 'snp CNV data']['sample-id'].unique().tolist()\n",
+    "cnv_samples = cnv_samples[:10]\n",
+    "cnv_samples"
+   ],
+   "id": "b6497e406f51a6c2",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['tcga-a7-a13h-01a',\n",
+       " 'tcga-an-a0al-01a',\n",
+       " 'tcga-d8-a1xm-10a',\n",
+       " 'tcga-a2-a04v-10a',\n",
+       " 'tcga-ar-a0tx-01a',\n",
+       " 'tcga-ll-a9q3-10a',\n",
+       " 'tcga-ol-a66h-10a',\n",
+       " 'tcga-d8-a27r-01a',\n",
+       " 'tcga-bh-a18t-11a',\n",
+       " 'tcga-a8-a06t-01a']"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 51
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-07-16T18:46:22.049421Z",
+     "start_time": "2025-07-16T18:46:12.045854Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "cnv_df = pqd.sample_measurements(dataset, 'snp CNV data', cnv_samples, db_name=database, timeout=120)\n",
+    "cnv_df"
+   ],
+   "id": "f9c37bc59e59d09a",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "               db-id                                     measurement-id  \\\n",
+       "0     17592187609808    tcga-d8-a1xm-10a-GRCh37:chr1:+:3218610:84897981   \n",
+       "1     17592187609811   tcga-d8-a1xm-10a-GRCh37:chr1:+:84900968:84901637   \n",
+       "2     17592187609813  tcga-d8-a1xm-10a-GRCh37:chr1:+:84903286:247813706   \n",
+       "3     17592187609815    tcga-d8-a1xm-10a-GRCh37:chr2:+:484222:242476062   \n",
+       "4     17592187609817   tcga-d8-a1xm-10a-GRCh37:chr3:+:2212571:197538677   \n",
+       "...              ...                                                ...   \n",
+       "1155  17592188068986  tcga-bh-a18t-11a-GRCh37:chr21:+:15347621:47678774   \n",
+       "1156  17592188068988  tcga-bh-a18t-11a-GRCh37:chr22:+:17423930:49331012   \n",
+       "1157  17592188068990   tcga-bh-a18t-11a-GRCh37:chr23:+:3157107:26896610   \n",
+       "1158  17592188068992  tcga-bh-a18t-11a-GRCh37:chr23:+:26897763:26903542   \n",
+       "1159  17592188068994  tcga-bh-a18t-11a-GRCh37:chr23:+:26903711:15490...   \n",
+       "\n",
+       "                                    measurement-uid  \\\n",
+       "0     [tcga-brca, 323d056054bd78b823e7ac6973981543]   \n",
+       "1     [tcga-brca, acbb98d687078bcf45dd768576ae9d8d]   \n",
+       "2     [tcga-brca, c1668ce6474fe9fb500f22703539a370]   \n",
+       "3     [tcga-brca, 24eb05f2c699e686fdd6777cc0c16863]   \n",
+       "4     [tcga-brca, 48837855b213115d0ed01e14446117e8]   \n",
+       "...                                             ...   \n",
+       "1155  [tcga-brca, c7c47fc3654f1a6e755edb75eb960d09]   \n",
+       "1156  [tcga-brca, 3c442f95d5d4fb264f97bde372e783fa]   \n",
+       "1157  [tcga-brca, 8ed0f1b84badf371bb6bf5602da3f5a5]   \n",
+       "1158  [tcga-brca, 8de24161f49478184f97ba904af60543]   \n",
+       "1159  [tcga-brca, f6ba3fc2bb35b570d9b6c0cfe8117f7f]   \n",
+       "\n",
+       "      measurement-segment-mean-lrr measurement-sample-sample-id  \\\n",
+       "0                           0.0036             tcga-d8-a1xm-10a   \n",
+       "1                          -1.0001             tcga-d8-a1xm-10a   \n",
+       "2                           0.0031             tcga-d8-a1xm-10a   \n",
+       "3                          -0.0029             tcga-d8-a1xm-10a   \n",
+       "4                          -0.0004             tcga-d8-a1xm-10a   \n",
+       "...                            ...                          ...   \n",
+       "1155                       -0.0017             tcga-bh-a18t-11a   \n",
+       "1156                        0.0008             tcga-bh-a18t-11a   \n",
+       "1157                        0.0013             tcga-bh-a18t-11a   \n",
+       "1158                       -1.1763             tcga-bh-a18t-11a   \n",
+       "1159                        0.0004             tcga-bh-a18t-11a   \n",
+       "\n",
+       "                 measurement-cnv-cnv-id  \n",
+       "0        GRCh37:chr1:+:3218610:84897981  \n",
+       "1       GRCh37:chr1:+:84900968:84901637  \n",
+       "2      GRCh37:chr1:+:84903286:247813706  \n",
+       "3        GRCh37:chr2:+:484222:242476062  \n",
+       "4       GRCh37:chr3:+:2212571:197538677  \n",
+       "...                                 ...  \n",
+       "1155   GRCh37:chr21:+:15347621:47678774  \n",
+       "1156   GRCh37:chr22:+:17423930:49331012  \n",
+       "1157    GRCh37:chr23:+:3157107:26896610  \n",
+       "1158   GRCh37:chr23:+:26897763:26903542  \n",
+       "1159  GRCh37:chr23:+:26903711:154905589  \n",
+       "\n",
+       "[1160 rows x 6 columns]"
+      ],
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>db-id</th>\n",
+       "      <th>measurement-id</th>\n",
+       "      <th>measurement-uid</th>\n",
+       "      <th>measurement-segment-mean-lrr</th>\n",
+       "      <th>measurement-sample-sample-id</th>\n",
+       "      <th>measurement-cnv-cnv-id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>17592187609808</td>\n",
+       "      <td>tcga-d8-a1xm-10a-GRCh37:chr1:+:3218610:84897981</td>\n",
+       "      <td>[tcga-brca, 323d056054bd78b823e7ac6973981543]</td>\n",
+       "      <td>0.0036</td>\n",
+       "      <td>tcga-d8-a1xm-10a</td>\n",
+       "      <td>GRCh37:chr1:+:3218610:84897981</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>17592187609811</td>\n",
+       "      <td>tcga-d8-a1xm-10a-GRCh37:chr1:+:84900968:84901637</td>\n",
+       "      <td>[tcga-brca, acbb98d687078bcf45dd768576ae9d8d]</td>\n",
+       "      <td>-1.0001</td>\n",
+       "      <td>tcga-d8-a1xm-10a</td>\n",
+       "      <td>GRCh37:chr1:+:84900968:84901637</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>17592187609813</td>\n",
+       "      <td>tcga-d8-a1xm-10a-GRCh37:chr1:+:84903286:247813706</td>\n",
+       "      <td>[tcga-brca, c1668ce6474fe9fb500f22703539a370]</td>\n",
+       "      <td>0.0031</td>\n",
+       "      <td>tcga-d8-a1xm-10a</td>\n",
+       "      <td>GRCh37:chr1:+:84903286:247813706</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>17592187609815</td>\n",
+       "      <td>tcga-d8-a1xm-10a-GRCh37:chr2:+:484222:242476062</td>\n",
+       "      <td>[tcga-brca, 24eb05f2c699e686fdd6777cc0c16863]</td>\n",
+       "      <td>-0.0029</td>\n",
+       "      <td>tcga-d8-a1xm-10a</td>\n",
+       "      <td>GRCh37:chr2:+:484222:242476062</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>17592187609817</td>\n",
+       "      <td>tcga-d8-a1xm-10a-GRCh37:chr3:+:2212571:197538677</td>\n",
+       "      <td>[tcga-brca, 48837855b213115d0ed01e14446117e8]</td>\n",
+       "      <td>-0.0004</td>\n",
+       "      <td>tcga-d8-a1xm-10a</td>\n",
+       "      <td>GRCh37:chr3:+:2212571:197538677</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1155</th>\n",
+       "      <td>17592188068986</td>\n",
+       "      <td>tcga-bh-a18t-11a-GRCh37:chr21:+:15347621:47678774</td>\n",
+       "      <td>[tcga-brca, c7c47fc3654f1a6e755edb75eb960d09]</td>\n",
+       "      <td>-0.0017</td>\n",
+       "      <td>tcga-bh-a18t-11a</td>\n",
+       "      <td>GRCh37:chr21:+:15347621:47678774</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1156</th>\n",
+       "      <td>17592188068988</td>\n",
+       "      <td>tcga-bh-a18t-11a-GRCh37:chr22:+:17423930:49331012</td>\n",
+       "      <td>[tcga-brca, 3c442f95d5d4fb264f97bde372e783fa]</td>\n",
+       "      <td>0.0008</td>\n",
+       "      <td>tcga-bh-a18t-11a</td>\n",
+       "      <td>GRCh37:chr22:+:17423930:49331012</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1157</th>\n",
+       "      <td>17592188068990</td>\n",
+       "      <td>tcga-bh-a18t-11a-GRCh37:chr23:+:3157107:26896610</td>\n",
+       "      <td>[tcga-brca, 8ed0f1b84badf371bb6bf5602da3f5a5]</td>\n",
+       "      <td>0.0013</td>\n",
+       "      <td>tcga-bh-a18t-11a</td>\n",
+       "      <td>GRCh37:chr23:+:3157107:26896610</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1158</th>\n",
+       "      <td>17592188068992</td>\n",
+       "      <td>tcga-bh-a18t-11a-GRCh37:chr23:+:26897763:26903542</td>\n",
+       "      <td>[tcga-brca, 8de24161f49478184f97ba904af60543]</td>\n",
+       "      <td>-1.1763</td>\n",
+       "      <td>tcga-bh-a18t-11a</td>\n",
+       "      <td>GRCh37:chr23:+:26897763:26903542</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1159</th>\n",
+       "      <td>17592188068994</td>\n",
+       "      <td>tcga-bh-a18t-11a-GRCh37:chr23:+:26903711:15490...</td>\n",
+       "      <td>[tcga-brca, f6ba3fc2bb35b570d9b6c0cfe8117f7f]</td>\n",
+       "      <td>0.0004</td>\n",
+       "      <td>tcga-bh-a18t-11a</td>\n",
+       "      <td>GRCh37:chr23:+:26903711:154905589</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>1160 rows × 6 columns</p>\n",
+       "</div>"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 52
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-07-16T18:57:00.669868Z",
+     "start_time": "2025-07-16T18:57:00.639366Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "gx_samples = assays_for_sub[['sample-id', 'measurement-set-name']]\n",
+    "gx_samples = gx_samples[gx_samples['measurement-set-name'] == 'gx']\n",
+    "gx_samples_sub = gx_samples['sample-id'].unique().tolist()[:10]\n",
+    "gx_samples_sub[:1]"
+   ],
+   "id": "bc968d478c54c417",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['tcga-ac-a3w6-01a']"
+      ]
+     },
+     "execution_count": 63,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 63
   }
  ],
  "metadata": {

--- a/patternq/query.py
+++ b/patternq/query.py
@@ -27,14 +27,16 @@ def make_headers(accept="text/plain") -> Dict[str, str]:
             "Accept": accept}
 
 
-def list_datasets() -> List[str]:
-    endpoint = f"{commons_endpoint()}/api-v1/list/datasets"
-    headers = make_headers(accept="application/json")
-    resp = requests.post(endpoint, headers=headers)
-    if resp.status_code != 200:
-        resp.raise_for_status()
-    else:
-        return resp.json()
+# -- TODO: waiting on list API auth conveyance changes --
+#
+#def list_datasets() -> List[str]:
+#    endpoint = f"{commons_endpoint()}/api-v1/list/datasets"
+#    headers = make_headers(accept="application/json")
+#    resp = requests.post(endpoint, headers=headers)
+#    if resp.status_code != 200:
+#        resp.raise_for_status()
+#    else:
+#        return resp.json()
 
 
 def set_db(db_name: str):

--- a/tests/livedev.py
+++ b/tests/livedev.py
@@ -1,13 +1,11 @@
 import pandas as pd
-import patternq.query as pqq
 import patternq.dataset as pqd
 import patternq.reference as pqr
-import patternq.helpers as pqh
 
 pd.options.display.max_columns = 10
 
 sub_id = "TCGA-A7-A0DB"
-assays_for_sub = pqd.assays_for_patients([sub_id], db_name='tcga-brca')
+assays_for_sub = pqd.patient_assays('tcga-brca', [sub_id], db_name='tcga-brca')
 assays_for_sub
 
 samples = pqd.samples("tcga-brca", db_name='tcga-brca')
@@ -24,9 +22,9 @@ gsyms
 genes = pqr.genes(db_name='tcga-brca', timeout=90)
 genes
 
-# -- this takes a little while, so uncomment with care --
-# measurements = pqd.measurements("gx", "rsem_normalized_count")
-# measurements
+measurements = pqd.measurements('tcga-brca', "tumor purity", db_name="tcga-brca")
+measurements
+
 sites = pqr.gdc_anatomic_sites(db_name='tcga-brca')
 sites
 
@@ -49,13 +47,5 @@ var
 # vars = pqr.variants("tcga-brca", timeout=120)
 # vars
 
-
-# -- for tcga, too large
-# meas = pqd.all_measurements("tcga-brca", "baseline mutations", db_name="tcga-brca",
-#                             timeout=120)
-#.meas
-
-
-patients = pqd.all_subjects("tcga-brca", db_name="tcga-brca")
+patients = pqd.subjects("tcga-brca", db_name="tcga-brca")
 patients
-


### PR DESCRIPTION
- measurements query was bugged due to shared nested object state in samples query, now fixed
- livedev tests and variant analysis example notebooks updated for latest api
- fix mistakenly disabled datasets query and disable list api call or datasets, as originally intended.